### PR TITLE
Fix: Health check for Isley placed  under devices section.

### DIFF
--- a/services/isley/docker-compose.yml
+++ b/services/isley/docker-compose.yml
@@ -11,13 +11,13 @@ services:
       - TS_STATE_DIR=/var/lib/tailscale
       - TS_SERVE_CONFIG=/config/serve.json # Tailsacale Serve configuration to expose the web interface on your local Tailnet - remove this line if not required
       - TS_USERSPACE=false
+      - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
+      - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
     devices:
       - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
-      - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
-      - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
     cap_add:
       - net_admin # Tailscale requirement
       - sys_module # Tailscale requirement


### PR DESCRIPTION
# Pull Request Title: Fix: Health check for Isley placed  under devices section.
## Description

Fix: Health check for Isley placed  under devices section.

## Related Issues

- N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

Got the error: "Error response from daemon: error gathering device information while adding custom device "TS_ENABLE_HEALTH_CHECK=true": no such file or directory"

This is because the lines underneath were misplaced under device. I checked the full repo and this was the only compose file with this bug. 

      - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
      - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint

Docker compose up -d gives no 
errors anymore. 

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix or feature works
- [ ] I have updated necessary documentation (e.g. frontpage `README.md`)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

- N/A

## Additional Notes

- N/A