### PR TITLE
Added MagicDNS Environment Option + Small fixes

### DIFF
--- a/services/adguardhome/docker-compose.yml
+++ b/services/adguardhome/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/audiobookshelf/docker-compose.yml
+++ b/services/audiobookshelf/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/bazarr/docker-compose.yml
+++ b/services/bazarr/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/beszel/agent/docker-compose.yml
+++ b/services/beszel/agent/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/beszel/hub/docker-compose.yml
+++ b/services/beszel/hub/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/changedetection/docker-compose.yml
+++ b/services/changedetection/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/clipcascade/docker-compose.yml
+++ b/services/clipcascade/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/cyberchef/docker-compose.yml
+++ b/services/cyberchef/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/ddns-updater/docker-compose.yml
+++ b/services/ddns-updater/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/dozzle/docker-compose.yml
+++ b/services/dozzle/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/excalidraw/docker-compose.yml
+++ b/services/excalidraw/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/gokapi/docker-compose.yml
+++ b/services/gokapi/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/homarr/docker-compose.yml
+++ b/services/homarr/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/isley/docker-compose.yml
+++ b/services/isley/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/it-tools/docker-compose.yml
+++ b/services/it-tools/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/jellyfin/docker-compose.yml
+++ b/services/jellyfin/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/languagetool/docker-compose.yml
+++ b/services/languagetool/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/linkding/docker-compose.yml
+++ b/services/linkding/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/nextcloud/docker-compose.yml
+++ b/services/nextcloud/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/nodered/docker-compose.yml
+++ b/services/nodered/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/pihole/docker-compose.yml
+++ b/services/pihole/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/pingvin-share/docker-compose.yml
+++ b/services/pingvin-share/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/plex/docker-compose.yml
+++ b/services/plex/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/portainer/docker-compose.yml
+++ b/services/portainer/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/qbittorrent/docker-compose.yml
+++ b/services/qbittorrent/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/radarr/docker-compose.yml
+++ b/services/radarr/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/resilio-sync/docker-compose.yml
+++ b/services/resilio-sync/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/searxng/docker-compose.yml
+++ b/services/searxng/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/slink/docker-compose.yml
+++ b/services/slink/docker-compose.yml
@@ -11,6 +11,9 @@ services:
       - TS_STATE_DIR=/var/lib/tailscale
       - TS_SERVE_CONFIG=/config/serve.json # Tailsacale Serve configuration to expose the web interface on your local Tailnet - remove this line if not required
       - TS_USERSPACE=false
+      - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
+      - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
@@ -19,13 +22,13 @@ services:
     cap_add:
       - net_admin # Tailscale requirement
       - sys_module # Tailscale requirement
-    ports:
-      - 0.0.0.0:${SERVICEPORT}:${SERVICEPORT} # Binding port ${SERVICE}PORT to the local network - may be removed if only exposure to your Tailnet is required
+    #ports:
+    #  - 0.0.0.0:${SERVICEPORT}:${SERVICEPORT} # Binding port ${SERVICE}PORT to the local network - may be removed if only exposure to your Tailnet is required
     # If any DNS issues arise, use your preferred DNS provider by uncommenting the config below
-    # dns: 
-    #   - ${DNS_SERVER}
+    #dns: 
+    #  - ${DNS_SERVER}
     healthcheck:
-      test: ["CMD", "tailscale", "status"] # Check if Tailscale is running
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:41234/healthz"] # Check Tailscale has a Tailnet IP and is operational
       interval: 1m # How often to perform the check
       timeout: 10s # Time to wait for the check to succeed
       retries: 3 # Number of retries before marking as unhealthy
@@ -42,22 +45,22 @@ services:
       - PGID=1000
       - TZ=Europe/Amsterdam
 
-    # Your application hostname
-    - ORIGIN=https://your-domain.com
-    
-    # Require user approval before they can upload images
-    - USER_APPROVAL_REQUIRED=true
-    
-    # User password requirements
-    - USER_PASSWORD_MIN_LENGTH=8
-    - USER_PASSWORD_REQUIREMENTS=15 # bitmask of requirements 
-    
-    # Maximum image size allowed to be uploaded (no more than 50M)
-    - IMAGE_MAX_SIZE=15M
-    
-    # Storage provider to use. 
-    # Available options are local and smb
-    - STORAGE_PROVIDER=local
+      # Your application hostname
+      - ORIGIN=https://your-domain.com
+
+      # Require user approval before they can upload images
+      - USER_APPROVAL_REQUIRED=true
+
+      # User password requirements
+      - USER_PASSWORD_MIN_LENGTH=8
+      - USER_PASSWORD_REQUIREMENTS=15 # bitmask of requirements 
+
+      # Maximum image size allowed to be uploaded (no more than 50M)
+      - IMAGE_MAX_SIZE=15M
+
+      # Storage provider to use. 
+      # Available options are local and smb
+      - STORAGE_PROVIDER=local
     volumes:
       - ${PWD}/${SERVICE}-data/var/data:/app/var/data
       - ${PWD}/${SERVICE}-data/images:/app/slink/images

--- a/services/sonarr/docker-compose.yml
+++ b/services/sonarr/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/speedtest-tracker/docker-compose.yml
+++ b/services/speedtest-tracker/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/stirlingpdf/docker-compose.yml
+++ b/services/stirlingpdf/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/tailscale-exit-node/docker-compose.yml
+++ b/services/tailscale-exit-node/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/tautulli/docker-compose.yml
+++ b/services/tautulli/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/technitium/docker-compose.yml
+++ b/services/technitium/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/traefik/docker-compose.yml
+++ b/services/traefik/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/uptime-kuma/docker-compose.yml
+++ b/services/uptime-kuma/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/vaultwarden/docker-compose.yml
+++ b/services/vaultwarden/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/templates/service-template/docker-compose.yml
+++ b/templates/service-template/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
@@ -21,11 +22,11 @@ services:
     cap_add:
       - net_admin # Tailscale requirement
       - sys_module # Tailscale requirement
-    ports:
-      - 0.0.0.0:${SERVICEPORT}:${SERVICEPORT} # Binding port ${SERVICE}PORT to the local network - may be removed if only exposure to your Tailnet is required
+    #ports:
+    #  - 0.0.0.0:${SERVICEPORT}:${SERVICEPORT} # Binding port ${SERVICE}PORT to the local network - may be removed if only exposure to your Tailnet is required
     # If any DNS issues arise, use your preferred DNS provider by uncommenting the config below
-    # dns: 
-    #   - ${DNS_SERVER}
+    #dns: 
+    #  - ${DNS_SERVER}
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:41234/healthz"] # Check Tailscale has a Tailnet IP and is operational
       interval: 1m # How often to perform the check


### PR DESCRIPTION
# Pull Request Title: Added MagicDNS Environment Option + Small fixes

## Description

- Added [MagicDNS](https://tailscale.com/kb/1081/magicdns) option to environment
    - `- TS_EXTRA_ARGS=--accept-dns=true`
- Updated service template
- Minor fix in Slink

## Related Issues

- N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [X] Refactoring

## How Has This Been Tested?

- N/A

## Checklist

- [X] I have performed a self-review of my code
- [X] I have added tests that prove my fix or feature works
- [X] I have updated necessary documentation (e.g. frontpage `README.md`)
- [X] Any dependent changes have been merged and published in downstream modules
