### PR TITLE
Caddy Web Server Addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ If you would like to add your own config, you can use the [service-template](tem
 | 🛡️ **AdGuard Home**        | Network-wide software for blocking ads and tracking.                            | [Details](services/adguardhome)         |
 | 🧩 **Pi-hole**             | A network-level ad blocker that acts as a DNS sinkhole.                         | [Details](services/pihole)              |
 | 🔒 **Technitium DNS**      | An open-source DNS server that can be used for self-hosted DNS services.        | [Details](services/technitium)          |
+| 🌐 **Caddy**               | Caddy is an extensible server platform that uses TLS by default.                | [Details](services/caddy)             |
 | 🌐 **Traefik**             | A modern reverse proxy and load balancer for microservices.                     | [Details](services/traefik)             |
 | 🚀 **Tailscale Exit Node** | Configure a device to act as an exit node for your Tailscale network.           | [Details](services/tailscale-exit-node) |
 | 🌐 **DDNS Updater**        | A self-hosted solution to keep DNS A/AAAA records updated automatically.        | [Details](services/ddns-updater)        |

--- a/services/caddy/.env
+++ b/services/caddy/.env
@@ -1,0 +1,8 @@
+#version=1.0
+#url=https://github.com/2Tiny2Scale/tailscale-docker-sidecar-configs
+#COMPOSE_PROJECT_NAME= // only use in multiple deployments on the same infra
+SERVICE=caddy  # If this is changed please set docker-compose.yml services:caddy_proxy:healthcheck $SERVICE to the string caddy. Also update the Caddyfile FQDN.
+IMAGE_URL=caddy:latest
+SERVICEPORT=80
+TS_AUTHKEY=
+DNS_SERVER=9.9.9.9

--- a/services/caddy/Caddyfile
+++ b/services/caddy/Caddyfile
@@ -1,0 +1,5 @@
+# ${SERVICE}.magicDNSname.ts.net
+http://caddy.MagicDNSname.ts.net {
+	# respond "Hello, world!"
+	reverse_proxy http://whoami
+}

--- a/services/caddy/README.md
+++ b/services/caddy/README.md
@@ -11,6 +11,7 @@ This Docker Compose configuration sets up [Caddy](https://github.com/caddyserver
 In this setup, the `tailscale-caddy` service runs Tailscale, which manages secure networking for the Caddy service. The `caddy_proxy` service uses the Tailscale network stack via Docker's `network_mode: service:` configuration. This ensures that Caddy’s dashboard and routing functionalities are only accessible through the Tailscale network (or locally, if preferred), adding an extra layer of privacy and security to your network architecture.
 
 To get this working:
+
 - Update the FQDN in `Caddyfile` to match your `${SERVICE}.MagicDNSname.ts.net`.
 - Update the TS_AUTHKEY in the .env file to your Tailscale key.
 
@@ -18,4 +19,4 @@ If you change the `SERVICE=caddy` line in the .env file, the hostname of the FQD
 
 The example `docker-compose.yml` uses a simple webserver for testing purposes.
 
-Within your Tailscale dashboard do you have [HTTPS](https://tailscale.com/kb/1153/enabling-https) and [MagicDNS](https://tailscale.com/kb/1081/magicdns) enabled? If so, remove the http:// from the Caddyfile and Caddy should automatically provision a public HTTPS certificate from Let's Encrypt via the Tailscale infrastructure. The certificate takes ~20s to be procured upon first visit.
+Within your Tailscale dashboard do you have [HTTPS](https://tailscale.com/kb/1153/enabling-https) and [MagicDNS](https://tailscale.com/kb/1081/magicdns) enabled? If so, remove the http:// from the Caddyfile and Caddy should automatically provision a public HTTPS certificate from Let's Encrypt via the Tailscale infrastructure. The certificate takes ~20s to be procured upon first visit. This is further documented in [Caddy certificates on Tailscale](https://tailscale.com/kb/1190/caddy-certificates).

--- a/services/caddy/README.md
+++ b/services/caddy/README.md
@@ -1,0 +1,17 @@
+# Caddy with Tailscale Sidecar Configuration
+
+This Docker Compose configuration sets up [Caddy](https://github.com/caddyserver/caddy-docker) with Tailscale as a sidecar container to securely manage and route your traffic over a private Tailscale network. By integrating Tailscale, you can enhance the security and privacy of your Caddy instance, ensuring that access is restricted to devices within your Tailscale network.
+
+## Caddy
+
+[Caddy](https://github.com/caddyserver/caddy-docker) is an extensible platform for deploying long-running services ("apps") using a single, unified configuration. It is enterprise-ready, extensible, open source, and provides automatic HTTPS. By incorporating Tailscale, your Caddy instance is safeguarded, ensuring that only authorized users and devices on your Tailscale network can access your applications and services.
+
+## Configuration Overview
+
+In this setup, the `tailscale-caddy` service runs Tailscale, which manages secure networking for the Caddy service. The `caddy_proxy` service uses the Tailscale network stack via Docker's `network_mode: service:` configuration. This ensures that Caddy’s dashboard and routing functionalities are only accessible through the Tailscale network (or locally, if preferred), adding an extra layer of privacy and security to your network architecture.
+
+Update the FQDN in `Caddyfile` to match your `${SERVICE}.MagicDNSname.ts.net`. If you change the `SERVICE=caddy` line in the .env file, the hostname of the FQDN in the Caddyfile must be updated as well. Additionally please replace $SERVICE in docker-compose.yml services:caddy_proxy:healthcheck with the string caddy.
+
+The example `docker-compose.yml` uses a simple webserver for testing purposes.
+
+Within your Tailscale dashboard do you have [HTTPS](https://tailscale.com/kb/1153/enabling-https) and [MagicDNS](https://tailscale.com/kb/1081/magicdns) enabled? If so, remove the http:// from the Caddyfile and Caddy should automatically provision a public HTTPS certificate from Let's Encrypt via the Tailscale infrastructure. The certificate takes ~20s to be procured upon first visit.

--- a/services/caddy/README.md
+++ b/services/caddy/README.md
@@ -10,7 +10,11 @@ This Docker Compose configuration sets up [Caddy](https://github.com/caddyserver
 
 In this setup, the `tailscale-caddy` service runs Tailscale, which manages secure networking for the Caddy service. The `caddy_proxy` service uses the Tailscale network stack via Docker's `network_mode: service:` configuration. This ensures that Caddy’s dashboard and routing functionalities are only accessible through the Tailscale network (or locally, if preferred), adding an extra layer of privacy and security to your network architecture.
 
-Update the FQDN in `Caddyfile` to match your `${SERVICE}.MagicDNSname.ts.net`. If you change the `SERVICE=caddy` line in the .env file, the hostname of the FQDN in the Caddyfile must be updated as well. Additionally please replace $SERVICE in docker-compose.yml services:caddy_proxy:healthcheck with the string caddy.
+To get this working:
+- Update the FQDN in `Caddyfile` to match your `${SERVICE}.MagicDNSname.ts.net`.
+- Update the TS_AUTHKEY in the .env file to your Tailscale key.
+
+If you change the `SERVICE=caddy` line in the .env file, the hostname of the FQDN in the Caddyfile must be updated as well. Additionally please replace $SERVICE in docker-compose.yml services:caddy_proxy:healthcheck with the string caddy.
 
 The example `docker-compose.yml` uses a simple webserver for testing purposes.
 

--- a/services/caddy/docker-compose.yml
+++ b/services/caddy/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     restart: always
 
   # ${SERVICE}
-  caddy_proxy:
+  application:
     image: ${IMAGE_URL} # Image to be used
     network_mode: service:tailscale # Sidecar configuration to route ${SERVICE} through Tailscale
     container_name: app-${SERVICE} # Name for local container management

--- a/services/caddy/docker-compose.yml
+++ b/services/caddy/docker-compose.yml
@@ -1,0 +1,67 @@
+services:
+# Make sure you have updated/checked the .env file with the correct variables. 
+# All the ${ xx } need to be defined there.
+  # Tailscale Sidecar Configuration
+  tailscale:
+    image: tailscale/tailscale:latest # Image to be used
+    container_name: tailscale-${SERVICE} # Name for local container management
+    hostname: ${SERVICE} # Name used within your Tailscale environment
+    environment:
+      - TS_AUTHKEY=${TS_AUTHKEY}
+      - TS_STATE_DIR=/var/lib/tailscale
+      - TS_SERVE_CONFIG=/config/serve.json # Tailsacale Serve configuration to expose the web interface on your local Tailnet - remove this line if not required
+      - TS_USERSPACE=false
+      - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
+      - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
+      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+    volumes:
+      - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
+      - ${PWD}/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path
+      - ${PWD}/tailscale/tmp:/tmp # Share the tmp folder with the tailscale socket for TLS. Comment out if not required.
+    devices:
+      - /dev/net/tun:/dev/net/tun # Network configuration for Tailscale to work
+    cap_add:
+      - net_admin # Tailscale requirement
+      - sys_module # Tailscale requirement
+    #ports:
+    #  - 0.0.0.0:${SERVICEPORT}:${SERVICEPORT} # Binding port ${SERVICE}PORT to the local network - may be removed if only exposure to your Tailnet is required
+    # If any DNS issues arise, use your preferred DNS provider by uncommenting the config below
+    #dns: 
+    #  - ${DNS_SERVER}
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:41234/healthz"] # Check Tailscale has a Tailnet IP and is operational
+      interval: 1m # How often to perform the check
+      timeout: 10s # Time to wait for the check to succeed
+      retries: 3 # Number of retries before marking as unhealthy
+      start_period: 10s # Time to wait before starting health checks
+    restart: always
+
+  # ${SERVICE}
+  caddy_proxy:
+    image: ${IMAGE_URL} # Image to be used
+    network_mode: service:tailscale # Sidecar configuration to route ${SERVICE} through Tailscale
+    container_name: app-${SERVICE} # Name for local container management
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Europe/Amsterdam
+    volumes:
+      - $PWD/Caddyfile:/etc/caddy/Caddyfile
+      - $PWD/site:/srv
+      - $PWD/caddy_data:/data
+      - $PWD/caddy_config:/config
+      - $PWD/tailscale/tmp/tailscaled.sock:/var/run/tailscale/tailscaled.sock # mount the socket at the right place. Comment out if not required.
+    depends_on:
+      tailscale:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
+      interval: 1m # How often to perform the check
+      timeout: 10s # Time to wait for the check to succeed
+      retries: 3 # Number of retries before marking as unhealthy
+      start_period: 30s # Time to wait before starting health checks
+    restart: always
+
+# This is a sample internal website on port 80
+  whoami:
+    image: traefik/whoami:latest


### PR DESCRIPTION
# Pull Request Title: Add Caddy Web Server

## Caddy Web Server

Provide a brief description of the changes made in this pull request. Include the following:

- The intention is to include Caddy web server in the ScaleTail list.
- Default access is TCP port 80, as per ScaleTail philosophy.
- Automatic TLS is available with minor configuration.

## Related Issues

- [Create New Caddy Service #92](https://github.com/2Tiny2Scale/ScaleTail/issues/92) 

## Type of Change
- Addition of new service.

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

Describe the tests you ran to verify your changes. Provide instructions for reproducing the testing process:

1. Test with clear Docker environment. Ensure Tailscale machine *caddy* does not exist (yet). Populate TS_AUTHKEY in .env and FQDN in Caddyfile.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix or feature works
- [x] I have updated necessary documentation (e.g. frontpage `README.md`)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)
n/a

## Additional Notes
n/a