### PR TITLE
Update Accept DNS Parameter for Tailscale v1.84.0

### DIFF
--- a/services/adguardhome/docker-compose.yml
+++ b/services/adguardhome/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/audiobookshelf/docker-compose.yml
+++ b/services/audiobookshelf/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/bazarr/docker-compose.yml
+++ b/services/bazarr/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/beszel/agent/docker-compose.yml
+++ b/services/beszel/agent/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/beszel/hub/docker-compose.yml
+++ b/services/beszel/hub/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/caddy/docker-compose.yml
+++ b/services/caddy/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/changedetection/docker-compose.yml
+++ b/services/changedetection/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/clipcascade/docker-compose.yml
+++ b/services/clipcascade/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/cyberchef/docker-compose.yml
+++ b/services/cyberchef/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/ddns-updater/docker-compose.yml
+++ b/services/ddns-updater/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/donetick/docker-compose.yml
+++ b/services/donetick/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/dozzle/docker-compose.yml
+++ b/services/dozzle/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/dumbdo/docker-compose.yml
+++ b/services/dumbdo/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/eigenfocus/docker-compose.yml
+++ b/services/eigenfocus/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/excalidraw/docker-compose.yml
+++ b/services/excalidraw/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/flatnotes/docker-compose.yml
+++ b/services/flatnotes/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/ghost/docker-compose.yml
+++ b/services/ghost/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/gokapi/docker-compose.yml
+++ b/services/gokapi/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/haptic/docker-compose.yml
+++ b/services/haptic/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/homarr/docker-compose.yml
+++ b/services/homarr/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/home-assistant/docker-compose.yml
+++ b/services/home-assistant/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/isley/docker-compose.yml
+++ b/services/isley/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/it-tools/docker-compose.yml
+++ b/services/it-tools/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/jellyfin/docker-compose.yml
+++ b/services/jellyfin/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/kaneo/docker-compose.yml
+++ b/services/kaneo/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/karakeep/docker-compose.yml
+++ b/services/karakeep/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/languagetool/docker-compose.yml
+++ b/services/languagetool/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/linkding/docker-compose.yml
+++ b/services/linkding/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/metube/docker-compose.yml
+++ b/services/metube/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      - TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      - TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ./config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ./ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/miniqr/docker-compose.yml
+++ b/services/miniqr/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/nanote/docker-compose.yml
+++ b/services/nanote/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/nessus/docker-compose.yml
+++ b/services/nessus/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/nextcloud/docker-compose.yml
+++ b/services/nextcloud/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/nodered/docker-compose.yml
+++ b/services/nodered/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/pihole/docker-compose.yml
+++ b/services/pihole/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/pingvin-share/docker-compose.yml
+++ b/services/pingvin-share/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/plex/docker-compose.yml
+++ b/services/plex/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/pocket-id/docker-compose.yml
+++ b/services/pocket-id/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/portainer/docker-compose.yml
+++ b/services/portainer/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/qbittorrent/docker-compose.yml
+++ b/services/qbittorrent/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/radarr/docker-compose.yml
+++ b/services/radarr/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/resilio-sync/docker-compose.yml
+++ b/services/resilio-sync/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/searxng/docker-compose.yml
+++ b/services/searxng/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/slink/docker-compose.yml
+++ b/services/slink/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/sonarr/docker-compose.yml
+++ b/services/sonarr/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/speedtest-tracker/docker-compose.yml
+++ b/services/speedtest-tracker/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/stirlingpdf/docker-compose.yml
+++ b/services/stirlingpdf/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/tailscale-exit-node/docker-compose.yml
+++ b/services/tailscale-exit-node/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/tautulli/docker-compose.yml
+++ b/services/tautulli/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/technitium/docker-compose.yml
+++ b/services/technitium/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/traefik/docker-compose.yml
+++ b/services/traefik/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/uptime-kuma/docker-compose.yml
+++ b/services/uptime-kuma/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/services/vaultwarden/docker-compose.yml
+++ b/services/vaultwarden/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path

--- a/templates/service-template/docker-compose.yml
+++ b/templates/service-template/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - TS_USERSPACE=false
       - TS_ENABLE_HEALTH_CHECK=true              # Enable healthcheck endpoint: "/healthz"
       - TS_LOCAL_ADDR_PORT=127.0.0.1:41234       # The <addr>:<port> for the healthz endpoint
-      #- TS_EXTRA_ARGS=--accept-dns=true # Uncomment when using MagicDNS
+      #- TS_ACCEPT_DNS=true # Uncomment when using MagicDNS
     volumes:
       - ${PWD}/config:/config # Config folder used to store Tailscale files - you may need to change the path
       - ${PWD}/ts/state:/var/lib/tailscale # Tailscale requirement - you may need to change the path


### PR DESCRIPTION
# Pull Request Title: Update Accept DNS Parameter for Tailscale v1.84.0

## Description

Changing ` TS_EXTRA_ARGS=--accept-dns=true` to `- TS_ACCEPT_DNS=true` to follow [Tailscale documentation](https://tailscale.com/kb/1054/dns).

## Related Issues

- N/A

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

Local testing with Tailscale version 1.84.0

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added tests that prove my fix or feature works
- [X] I have updated necessary documentation (e.g. frontpage `README.md`)
- [X] Any dependent changes have been merged and published in downstream modules