### PR TITLE
AudioBookshelf patch

### DIFF
--- a/services/audiobookshelf/config/serve.json
+++ b/services/audiobookshelf/config/serve.json
@@ -8,7 +8,7 @@
     "${TS_CERT_DOMAIN}:443": {
       "Handlers": {
         "/": {
-          "Proxy": "http://127.0.0.1:13378" 
+          "Proxy": "http://127.0.0.1:80" 
         }
       }
     }


### PR DESCRIPTION
Changed port in serve.json to reflect the correct port the container serves.

# Pull Request Title: AudioBookshelf patch

## Description

AudioBookshelf patch

## Related Issues

- N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

Debian 12, docker compose. 

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix or feature works
- [x] I have updated necessary documentation (e.g. frontpage `README.md`)
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

<img width="1968" height="1663" alt="image" src="https://github.com/user-attachments/assets/1609b8fb-58af-46b5-94f2-27082ff825ca" />

## Additional Notes

- N/A
