### PR TITLE
Fix duplicate variable declaration for DB_DATABASE_NAME in .env

### DIFF
--- a/services/immich/.env
+++ b/services/immich/.env
@@ -39,4 +39,3 @@ DB_PASSWORD=postgres
 ###################################################################################
 DB_USERNAME=postgres
 DB_DATABASE_NAME=immich
-DB_DATABASE_NAME=immich


### PR DESCRIPTION
# Pull Request Title: Fix duplicate variable declaration for DB_DATABASE_NAME in .env

## Description

Removal of duplicate variable.

## Related Issues

- N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

- N/A

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix or feature works
- [x] I have updated necessary documentation (e.g. frontpage `README.md`)
- [x] Any dependent changes have been merged and published in downstream modules
