### PR TITLE
Fix volume mapping for music data in compose.yaml

### DIFF
--- a/services/picard/compose.yaml
+++ b/services/picard/compose.yaml
@@ -57,7 +57,7 @@ services:
       - TZ=Europe/Amsterdam # Change according to your timezone or set by mapping /etc/localtime between the host and the container.
     volumes:
       - ./${SERVICE}-data/config:/config:rw
-      - ./${SERVICE}-data/music:/config:rw
+      - ./${SERVICE}-data/music:/storage:rw
     depends_on:
       tailscale:
         condition: service_healthy


### PR DESCRIPTION
# Pull Request Title: Fix volume mapping for music data in compose.yaml

## Description

Fix volume mapping for music data in compose.yaml

## Related Issues

- Issue #194

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

Tested on
- OS:  Debian GNU/Linux 13 (trixie)
- Architecture: x86_64
- Kernel Version: 6.12.63+deb13-amd64

Docker:
- Server Version: 29.1.4
- API Version: 1.52
- Go Version: go1.25.5

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix or feature works
- [x] I have updated necessary documentation (e.g. frontpage `README.md`)
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

- N/A

## Additional Notes

- N/A
