### PR TITLE
Change IMAGE_URL to ghcr.io for bentopdf

### DIFF
--- a/services/bentopdf/.env
+++ b/services/bentopdf/.env
@@ -4,7 +4,7 @@
 
 # Service Configuration
 SERVICE=bentopdf
-IMAGE_URL=bentopdf/bentopdf:latest
+IMAGE_URL=ghcr.io/alam00000/bentopdf
 
 # Network Configuration
 SERVICEPORT=3000


### PR DESCRIPTION
# Pull Request Title: Change IMAGE_URL to ghcr.io for bentopdf

## Description

Change IMAGE_URL to ghcr.io for bentopdf as documented by bentopdf maintainer. Read more [here](https://github.com/alam00000/bentopdf/releases/tag/v1.16.1)

## Related Issues

- N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactoring

## How Has This Been Tested?

- N/A

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix or feature works
- [ ] I have updated necessary documentation (e.g. frontpage `README.md`)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

- N/A

## Additional Notes

- N/A
