### PR TITLE
Add default credentials section to Arcane README

### DIFF
--- a/services/arcane/README.md
+++ b/services/arcane/README.md
@@ -26,3 +26,8 @@ network_mode: service:tailscale-arcane
 ```
 
 This configuration routes all traffic through the Tailscale interface, ensuring that the Arcane web UI and API are accessible **only via your Tailscale network**. This provides a simple and secure way to access your Docker management console from all trusted devices while preventing public access to container controls.
+
+## Default Credentials
+
+* Username: `arcane`
+* Password: `arcane-admin`


### PR DESCRIPTION
# Pull Request Title: Add default credentials section to Arcane README

## Description

Add default credentials section to Arcane README

## Related Issues

- N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

- N/A

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix or feature works
- [x] I have updated necessary documentation (e.g. frontpage `README.md`)
- [ ] Any dependent changes have been merged and published in downstream modules
