### PR TITLE
Remove DOZZLE_AUTH_PROVIDER environment variable from application

### DIFF
--- a/services/dozzle/compose.yaml
+++ b/services/dozzle/compose.yaml
@@ -51,8 +51,6 @@ services:
     image: ${IMAGE_URL} # Image to be used
     network_mode: service:tailscale # Sidecar configuration to route ${SERVICE} through Tailscale
     container_name: app-${SERVICE} # Name for local container management
-    environment:
-      DOZZLE_AUTH_PROVIDER: simple
     volumes:
       - ./${SERVICE}-data/dozzle-data:/data
       - /var/run/docker.sock:/var/run/docker.sock:ro


### PR DESCRIPTION
# Pull Request Title: Remove DOZZLE_AUTH_PROVIDER environment variable from application

## Description

Remove DOZZLE_AUTH_PROVIDER environment variable from application since this is not required / prevents the container from starting by default.

## Related Issues

- N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactoring

## How Has This Been Tested?

Local lab testing.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix or feature works
- [x] I have updated necessary documentation (e.g. frontpage `README.md`)
- [x] Any dependent changes have been merged and published in downstream modules

