### PR TITLE
Make copyparty config be used by the service container

### DIFF
--- a/services/copyparty/compose.yaml
+++ b/services/copyparty/compose.yaml
@@ -67,6 +67,9 @@ services:
     network_mode: service:tailscale # Sidecar configuration to route ${SERVICE} through Tailscale
     container_name: app-${SERVICE} # Name for local container management
     user: "1000:1000"
+    configs:
+      - source: copyparty-config
+        target: /cfg/copyparty.conf
     volumes:
       - ./config:/cfg:z
       - /path/to/your/fileshare/top/folder:/w:z # Make sure to adjust to the location you want


### PR DESCRIPTION
copyparty-config already existed as a docker config but was not being used. This commit makes the application container write the file on the correct location as copyparty.conf. Copyparty will load and use the config file.

I have tested and confirmed it is working with this version.