### PR TITLE
Update Kaneo to v2.6.0

### DIFF
--- a/services/kaneo/.env
+++ b/services/kaneo/.env
@@ -3,21 +3,32 @@
 #COMPOSE_PROJECT_NAME= # Optional: only use when running multiple deployments on the same infrastructure.
 
 # Service Configuration
-SERVICE=kaneo
-IMAGE_URL_BACKEND=ghcr.io/usekaneo/api:latest
-IMAGE_URL_FRONTEND=ghcr.io/usekaneo/web:latest
-IMAGE_URL_DATABASE=postgres:16-alpine
+SERVICE=kaneo # Service name (e.g., adguard). Used as hostname in Tailscale and for container naming (app-${SERVICE}).
+IMAGE_URL_BACKEND=ghcr.io/usekaneo/api:latest # Docker image URL from container registry (e.g., adguard/adguard-home).
+IMAGE_URL_FRONTEND=ghcr.io/usekaneo/web:latest # Docker image URL from container registry (e.g., adguard/adguard-home).
+IMAGE_URL_DATABASE=postgres:16-alpine # Docker image URL from container registry (e.g., adguard/adguard-home).
 
 # Network Configuration
 # SERVICEPORT=
 SERVICEPORT_FRONTEND=5173
 SERVICEPORT_BACKEND=1337
 SERVICEPORT_DATABASE=5432
-DNS_SERVER=9.9.9.9
+DNS_SERVER=9.9.9.9 # Preferred DNS server for Tailscale. Uncomment the "dns:" section in compose.yaml to enable.
+
+# Tailscale Configuration
+TS_AUTHKEY= # Auth key from https://tailscale.com/admin/authkeys. See: https://tailscale.com/kb/1085/auth-keys#generate-an-auth-key for instructions.
+
+# Optional Service variables
+# PUID=1000
+
+#Time Zone setting for containers 
+TZ=Europe/Amsterdam # See: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+
+# Any Container environment variables are declared below. See https://docs.docker.com/compose/how-tos/environment-variables/
 
 # Kaneo Configuration
-KANEO_API_URL="https://kaneo.<your-tailnet>.net/api"
-KANEO_CLIENT_URL="https://kaneo.<your-tailnet>.net"
+KANEO_API_URL="https://kaneo.<your-tailnet>.ts.net/api"
+KANEO_CLIENT_URL="https://kaneo.<your-tailnet>.ts.net"
 
 # AUTH Configuration
 AUTH_SECRET=

--- a/services/kaneo/.env
+++ b/services/kaneo/.env
@@ -6,10 +6,27 @@
 SERVICE=kaneo
 IMAGE_URL_BACKEND=ghcr.io/usekaneo/api:latest
 IMAGE_URL_FRONTEND=ghcr.io/usekaneo/web:latest
+IMAGE_URL_DATABASE=postgres:16-alpine
 
 # Network Configuration
-SERVICEPORT=80
+# SERVICEPORT=
+SERVICEPORT_FRONTEND=5173
+SERVICEPORT_BACKEND=1337
+SERVICEPORT_DATABASE=5432
 DNS_SERVER=9.9.9.9
+
+# Kaneo Configuration
+KANEO_API_URL="https://kaneo.<your-tailnet>.net/api"
+KANEO_CLIENT_URL="https://kaneo.<your-tailnet>.net"
+
+# AUTH Configuration
+AUTH_SECRET=
+BETTER_AUTH_TRUSTED_PROXIES: "0.0.0.0/0"
+
+# DB Configuration
+DB_USERNAME=kaneo
+DB_DATABASE_NAME=kaneo
+DB_PASSWORD=
 
 # Tailscale Configuration
 TS_AUTHKEY=

--- a/services/kaneo/compose.yaml
+++ b/services/kaneo/compose.yaml
@@ -96,7 +96,7 @@ services:
     depends_on:
       tailscale:
         condition: service_healthy
-      kaneo-backend:
+      backend:
         condition: service_started
     restart: unless-stopped
 

--- a/services/kaneo/compose.yaml
+++ b/services/kaneo/compose.yaml
@@ -3,8 +3,10 @@ configs:
     content: |
       {"TCP":{"443":{"HTTPS":true}},
       "Web":{"$${TS_CERT_DOMAIN}:443":
-          {"Handlers":{"/":
-          {"Proxy":"http://127.0.0.1:80"}}}},
+          {"Handlers":{
+            "/api/":{"Proxy":"http://localhost:${SERVICEPORT_BACKEND}/api/"},
+            "/":{"Proxy":"http://localhost:${SERVICEPORT_FRONTEND}"}
+          }}},
       "AllowFunnel":{"$${TS_CERT_DOMAIN}:443":false}}
 
 services:
@@ -47,41 +49,56 @@ services:
       start_period: 10s # Time to wait before starting health checks
     restart: always
 
-  # ${SERVICE} - Backend
+  # ${SERVICE} - DB
+  postgres:
+    image: ${IMAGE_URL_DATABASE} # Image to be used
+    network_mode: service:tailscale # Sidecar configuration to route ${SERVICE} through Tailscale
+    container_name: app-${SERVICE}-postgres # Name for local container management
+    env_file:
+      - .env
+    environment:
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_USER: ${DB_USERNAME}
+      POSTGRES_DB: ${DB_DATABASE_NAME}
+    volumes:
+      - ./${SERVICE}-data/postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME} -d ${DB_DATABASE_NAME}"]
+      interval: 10s # How often to perform the check
+      timeout: 5s # Time to wait for the check to succeed
+      retries: 5 # Number of retries before marking as unhealthy
+      start_period: 30s # Time to wait before starting health checks
+    restart: unless-stopped
+
+  # ${SERVICE} - Backend (API)
   backend:
     image: ${IMAGE_URL_BACKEND} # Image to be used
     network_mode: service:tailscale # Sidecar configuration to route ${SERVICE} through Tailscale
     container_name: app-${SERVICE}-backend # Name for local container management
+    env_file:
+      - .env
     environment:
-      JWT_ACCESS: "change_me"
-      DB_PATH: "/app/apps/api/data/kaneo.db"
-    volumes:
-      - ./${SERVICE}-data/sqlite_data:/app/apps/api/data
+      DATABASE_URL: "postgresql://${DB_USERNAME}:${DB_PASSWORD}@localhost:${SERVICEPORT_DATABASE}/${DB_DATABASE_NAME}"
     depends_on:
       tailscale:
         condition: service_healthy
-    healthcheck:
-      test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
-      interval: 1m # How often to perform the check
-      timeout: 10s # Time to wait for the check to succeed
-      retries: 3 # Number of retries before marking as unhealthy
-      start_period: 30s # Time to wait before starting health checks
-    restart: always
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
 
-  # ${SERVICE} - Frontend
+  # ${SERVICE} - Frontend (Web)
   frontend:
     image: ${IMAGE_URL_FRONTEND} # Image to be used
     network_mode: service:tailscale # Sidecar configuration to route ${SERVICE} through Tailscale
     container_name: app-${SERVICE}-frontend # Name for local container management
-    environment:
-      KANEO_API_URL: "https://kaneo.<your-tailnet>/api"
+    env_file:
+      - .env
     depends_on:
       tailscale:
         condition: service_healthy
-    healthcheck:
-      test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
-      interval: 1m # How often to perform the check
-      timeout: 10s # Time to wait for the check to succeed
-      retries: 3 # Number of retries before marking as unhealthy
-      start_period: 30s # Time to wait before starting health checks
-    restart: always
+      kaneo-backend:
+        condition: service_started
+    restart: unless-stopped
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
# Pull Request Title: Update Kaneo compose.yaml to v2.6.0

## Description

Kaneo's configuration files were outdated and did not work with the latest official images.
This PR updates the compose.yaml and env file to match Kaneo's latest release.

## Related Issues

- Fixes #251 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactoring

## How Has This Been Tested?

1. Deployed the stack on my Ubuntu server using `docker compose up -d`
2. Confirmed Tailscale container joined the Tailnet successfully
3. Accessed the WebUI via MagicDNS URL on a mobile device over cellular and Wifi
4. Confirmend API and WebUI work together as intended by inspecting Firefox's developer tools network tab

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix or feature works
- [x] I have updated necessary documentation (e.g. frontpage `README.md`)
- [x] Any dependent changes have been merged and published in downstream modules

## Additional Notes

In order for the frontend to be able to communicate with the backend, I added a second proxy handler that matches `/api` to `localhost:<backend-port>/api/`. By doing so, the API can be accessed using the same MagicDNS url as the WebUI (by adding e.g. `/api/auth/get-session` at the end). This removes the need to create a separate Tailscale container just for the backend.
