### PR TITLE
Make SearXNG use valkey since it is installed

### DIFF
--- a/services/searxng/.env
+++ b/services/searxng/.env
@@ -18,3 +18,4 @@ TAILNET_NAME=
 # PUID=1000
 
 SEARXNG_SECRET= # Generate a random secret for searxng, e.g. using `openssl rand -hex 32`
+SEARXNG_VALKEY_URL=valkey://valkey-searxng:6379/0 # URL for valkey, format: valkey://<hostname>:<port>/<db>

--- a/services/searxng/README.md
+++ b/services/searxng/README.md
@@ -11,6 +11,7 @@ This Docker Compose configuration sets up [searXNG](https://github.com/searxng/s
 In this setup, the `tailscale-searxng` service runs Tailscale, which manages secure networking for the searXNG service. The `searxng` service utilizes the Tailscale network stack via Docker’s `network_mode: service:` configuration. This setup ensures that searXNG is only accessible through your Tailscale network (or locally, if preferred). With this configuration, you can enjoy a private, secure, and customizable search engine experience, free from user tracking or external access.
 
 We use `/searxng/settings.yml` copied from <https://github.com/searxng/searxng/blob/master/searx/settings.yml> as the default settings file. This dir is mounted as a volume, on docker and required for the first run.
+The default `settings.yml` does not use valkey ([valkey](https://github.com/searxng/searxng/blob/master/searx/settings.yml#L121) URL is set to `false`). We enable this by setting the `SEARXNG_VALKEY_URL` in `.env` file and using that in the `compose.yaml` file.
 
 ## References
 

--- a/services/searxng/compose.yaml
+++ b/services/searxng/compose.yaml
@@ -8,7 +8,7 @@ configs:
       "AllowFunnel":{"$${TS_CERT_DOMAIN}:443":false}}
 
 services:
-# Make sure you have updated/checked the .env file with the correct variables. 
+# Make sure you have updated/checked the .env file with the correct variables.
 # All the ${ xx } need to be defined there.
   # Tailscale Sidecar Configuration
   tailscale:
@@ -37,7 +37,7 @@ services:
     #ports:
     #  - 0.0.0.0:${SERVICEPORT}:${SERVICEPORT} # Binding port ${SERVICE}PORT to the local network - may be removed if only exposure to your Tailnet is required
     # If any DNS issues arise, use your preferred DNS provider by uncommenting the config below
-    # dns: 
+    # dns:
     #   - ${DNS_SERVER}
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:41234/healthz"] # Check Tailscale has a Tailnet IP and is operational
@@ -56,7 +56,8 @@ services:
       - PUID=1000
       - PGID=1000
       - TZ=Europe/Amsterdam
-      - SEARXNG_BASE_URL=https://searxng.${TAILNET_NAME}.ts.net/
+      - SEARXNG_BASE_URL=https://${SERVICE}.${TAILNET_NAME}.ts.net/
+      - SEARXNG_VALKEY_URL=${SEARXNG_VALKEY_URL}
     volumes:
       - ./searxng:/etc/searxng:rw
     cap_drop:
@@ -74,11 +75,11 @@ services:
     depends_on:
       tailscale:
         condition: service_healthy
-      redis:
+      valkey:
         condition: service_started
 
-  redis:
-    container_name: redis-searxng
+  valkey:
+    container_name: valkey-searxng
     image: docker.io/valkey/valkey:8-alpine
     command: valkey-server --save 30 1 --loglevel warning
     restart: unless-stopped


### PR DESCRIPTION
# Pull Request Title: Make SearXNG use valkey

## Description

SearXNG does not use valkey by default. The settings.yml sets the valkey url to false. This PR takes it into use.
It also replaces strings for 'redis' with 'valkey', since this stack is using valkey, not redis

## Related Issues

- None

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [x] Refactoring

## How Has This Been Tested?

I launched this stack using `docker compose up` locally and verified valkey is being used by:
- observing no connection errors from `app-searxng` container
- logging into `app-searxng` and checking SEARXNG_VALKEY_URL is set in env

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix or feature works
- [x] I have updated necessary documentation (e.g. frontpage `README.md`)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

None

## Additional Notes

None
