### PR TITLE
Added Missing FossFLOW docker-image URL

### DIFF
--- a/services/fossflow/compose.yaml
+++ b/services/fossflow/compose.yaml
@@ -49,7 +49,7 @@ services:
 
   # ${SERVICE}
   application:
-    image: ${IMAGE_URL} # Image to be used
+    image: stnsmith/fossflow:latest # Image to be used
     network_mode: service:tailscale # Sidecar configuration to route ${SERVICE} through Tailscale
     container_name: app-${SERVICE} # Name for local container management
     build:


### PR DESCRIPTION
# Added Docker Image URL missing in compose file for FossFLOW service
## Description

Added the missing Docker Image URL, which has been set as a variable but isn't defined in the .env

## Related Issues

- None

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

Describe the tests you ran to verify your changes. Provide instructions for reproducing the testing process:

Ran the docker compose

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix or feature works
- [ ] I have updated necessary documentation (e.g. frontpage `README.md`)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

If visual changes are made, include screenshots to demonstrate them.

## Additional Notes

Add any additional comments or information that may be relevant.
