### PR TITLE
Fix volume path syntax in compose.yaml of open-webui

### DIFF
--- a/services/open-webui/compose.yaml
+++ b/services/open-webui/compose.yaml
@@ -57,7 +57,7 @@ services:
       - WEBUI_SECRET_KEY=${WEBUI_SECRET_KEY}
       - TZ=${TZ}
     volumes:
-      - ./$(SERVICE)-data:/app/backend/data
+      - ./${SERVICE}-data:/app/backend/data
     depends_on:
       tailscale:
         condition: service_healthy


### PR DESCRIPTION
# open-webui: Fix volume path syntax in compose.yaml of open-webui
<!-- Examples: Dockhand: new service | Changedetection: fix port mapping -->
Fix volume path syntax in compose.yaml of open-webui

## Description
<!-- Briefly describe what changed. -->
Fix volume path syntax in compose.yaml of open-webui

## Related Issues
<!-- Link any related issues (e.g. Fixes #123). Use "None" if not applicable. -->

- None.

## Verification
<!-- Describe how you tested this change and include relevant proof such as logs, command output, or screenshots if useful. -->

Local machine.

## Checklist

- [x] I have performed a self-review of my code and followed the [templates](https://github.com/tailscale-dev/ScaleTail/tree/main/templates/service-template) structure.
- [x] I have added verification that the stack works as expected.
- [x] I have updated necessary documentation (e.g. frontpage [README.md](https://github.com/tailscale-dev/ScaleTail/blob/main/README.md) ).
- [x] I have selected the correct label(s) for this PR.

## Additional Context
<!-- Any extra info for reviewers, such as gotchas, special requirements, devices, or dependencies. Use "None" if not applicable. -->

- None.
