### PR TITLE
Remove healthcheck from Portainer service

### DIFF
--- a/services/portainer/compose.yaml
+++ b/services/portainer/compose.yaml
@@ -62,10 +62,4 @@ services:
     depends_on:
       tailscale:
         condition: service_healthy
-    healthcheck:
-      test: ["CMD", "pgrep", "-f", "${SERVICE}"] # Check if ${SERVICE} process is running
-      interval: 1m # How often to perform the check
-      timeout: 10s # Time to wait for the check to succeed
-      retries: 3 # Number of retries before marking as unhealthy
-      start_period: 30s # Time to wait before starting health checks
     restart: always


### PR DESCRIPTION
# Portainer: Remove healthcheck from Portainer service
<!-- Examples: Dockhand: new service | Changedetection: fix port mapping -->

## Description
<!-- Briefly describe what changed. -->
The Portainer health check is being removed because the official portainer/portainer-ce image is a minimal scratch-based image that does not include common utilities such as wget, curl, nc, or pgrep.

As a result, meaningful Docker health checks cannot be implemented reliably without switching to a different image variant. Since the container already uses restart: always, Docker will continue to restart Portainer if the process exits.

Users who require availability monitoring are encouraged to use an external monitoring solution such as Uptime Kuma.

This will fix #305

## Related Issues
<!-- Link any related issues (e.g. Fixes #123). Use "None" if not applicable. -->

- #305

## Verification
<!-- Describe how you tested this change and include relevant proof such as logs, command output, or screenshots if useful. -->

Tested on own system. 

## Checklist

- [x] I have performed a self-review of my code and followed the [templates](https://github.com/tailscale-dev/ScaleTail/tree/main/templates/service-template) structure.
- [x] I have added verification that the stack works as expected.
- [x] I have updated necessary documentation (e.g. frontpage [README.md](https://github.com/tailscale-dev/ScaleTail/blob/main/README.md) ).
- [x] I have selected the correct label(s) for this PR.

## Additional Context
<!-- Any extra info for reviewers, such as gotchas, special requirements, devices, or dependencies. Use "None" if not applicable. -->

- None.
